### PR TITLE
fix(generators): Add support for eventstruct

### DIFF
--- a/generators/cpp_client.py
+++ b/generators/cpp_client.py
@@ -3130,15 +3130,16 @@ def cpp_type_classes():
 #           }
 
 # Must create an "output" dictionary before any xcbgen imports.
-output = {'open'    : c_open,
-          'close'   : c_close,
-          'simple'  : c_simple, # lambda x, y: None,
-          'enum'    : lambda x, y: None,
-          'struct'  : lambda x, y: None,
-          'union'   : lambda x, y: None,
-          'request' : c_request,
-          'event'   : cpp_event,
-          'error'   : cpp_error,
+output = {'open'          : c_open,
+          'close'         : c_close,
+          'simple'        : c_simple, # lambda x, y: None,
+          'enum'          : lambda x, y: None,
+          'struct'        : lambda x, y: None,
+          'union'         : lambda x, y: None,
+          'request'       : c_request,
+          'event'         : cpp_event,
+          'error'         : cpp_error,
+          'eventstruct'   : lambda x, y: None,
           }
 
 # Boilerplate below this point


### PR DESCRIPTION
Newer xcb-proto commits after the 1.12 release require the 'eventstruct'
key in the output dictionary, otherwise the generator crashes.

I don't see a need for xpp to actually support the eventstruct key and
thus it uses a NOP lambda function