### PR TITLE
fix(cmake): Use right dir for xml proto files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,21 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 find_package(PkgConfig)
 pkg_check_modules(XCBPROTO REQUIRED xcb-proto)
 
+# Store the location of the proto xml files inside XCBPROTO_XCBINCLUDEDIR
+if(${CMAKE_VERSION} VERSION_LESS "3.4.0") 
+    # pkg_get_variable was introduced in 3.4.0 if it isn't available, we fall back to ${prefix}/share/xcb
+
+    if(NOT XCBPROTO_PREFIX)
+        set(XCBPROTO_PREFIX /usr)
+    endif()
+
+    set(XCBPROTO_XCBINCLUDEDIR ${XCBPROTO_PREFIX}/share/xcb)
+    message(STATUS "${PROJECT_NAME}: pkg_get_variable not supported, setting XCBPROTO_XCBINCLUDEDIR to ${XCBPROTO_XCBINCLUDEDIR}")
+else()
+    # The xml file that need to be included later are stored in xcbincludedir as defined in xcb-proto.pc
+    pkg_get_variable(XCBPROTO_XCBINCLUDEDIR xcb-proto xcbincludedir)
+endif()
+
 find_package(PythonInterp 2.7 REQUIRED)
 find_package(XCB REQUIRED XCB ICCCM EWMH UTIL IMAGE)
 
@@ -124,10 +139,7 @@ endif()
 
 set(PROTO_LIST)
 
-if(NOT XCBPROTO_PREFIX)
-  set(XCBPROTO_PREFIX /usr)
-endif()
-file(GLOB PROTO_LIST_RAW RELATIVE ${XCBPROTO_PREFIX}/share/xcb ${XCBPROTO_PREFIX}/share/xcb/*.xml)
+file(GLOB PROTO_LIST_RAW RELATIVE ${XCBPROTO_XCBINCLUDEDIR} ${XCBPROTO_XCBINCLUDEDIR}/*.xml)
 
 #
 # Filter glob
@@ -150,7 +162,7 @@ foreach(PROTO ${PROTO_LIST})
   add_custom_command(
     OUTPUT ${OUTPUT_FILE}
     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/generators/cpp_client.py -p "${PYTHON_XCBGEN}"
-    ${XCBPROTO_PREFIX}/share/xcb/${PROTO}.xml > ${OUTPUT_FILE})
+    ${XCBPROTO_XCBINCLUDEDIR}/${PROTO}.xml > ${OUTPUT_FILE})
   list(APPEND PROTO_HEADER_FILES ${OUTPUT_FILE})
 endforeach(PROTO)
 


### PR DESCRIPTION
As described in jaagr/polybar#750 `${XCBPROTO_PREFIX}/share/xcb` may not
point to the directory containing the xml proto files

If cmake 3.4 or up is used, the proper path (stored in the xcbincludedir
variable in xcb-proto.pc) can be fetched. Older versions fall back to
the way it was done before