### PR TITLE
fix(cmake): Specify library type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endforeach(PROTO)
 # Create project lib and commands
 #
 file(GLOB_RECURSE HEADER_FILES ${PROJECT_SOURCE_DIR}/include/*.hpp)
-add_library(${PROJECT_NAME} ${HEADER_FILES} ${PROTO_HEADER_FILES})
+add_library(${PROJECT_NAME} STATIC ${HEADER_FILES} ${PROTO_HEADER_FILES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${XPP_INCLUDE_DIRS})
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/include/xpp)


### PR DESCRIPTION
If BUILD_SHARED_LIBS is set to ON, xpp will build as a shared library
which we don't want.

Ref jaagr/polybar#1628