### PR TITLE
fix(window): add default copy cstr

### DIFF
--- a/include/xpp/window.hpp
+++ b/include/xpp/window.hpp
@@ -23,6 +23,7 @@ class window
     {}
 
   public:
+    window(const window&) = default;
     using base::base;
     using base::operator=;
 


### PR DESCRIPTION
The copy constructor must be declared explicitly since the implicit declaration is deprecated.
See https://github.com/jaagr/polybar/pull/1729.