### PR TITLE
Add missing <stdexcept> header

### DIFF
--- a/include/xpp/core.hpp
+++ b/include/xpp/core.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <memory>
+#include <stdexcept>
 #include <xcb/xcb.h>
 
 namespace xpp {


### PR DESCRIPTION
Newer compilers are more strict about which headers provide standard
exceptions (specifically GCC 10 in this case)