### PR TITLE
build: Don't search for xcbgen with python2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ set(XPP_LIBRARIES
 #
 # Loop through a hardcoded list of python executables to locate the python module "xcbgen"
 #
-foreach(CURRENT_EXECUTABLE python python3 python2 python2.7)
+foreach(CURRENT_EXECUTABLE python3 python)
   message(STATUS "Searching for xcbgen with " ${CURRENT_EXECUTABLE})
 
   execute_process(COMMAND "${CURRENT_EXECUTABLE}" "-c"
@@ -67,7 +67,7 @@ foreach(CURRENT_EXECUTABLE python python3 python2 python2.7)
 endforeach(CURRENT_EXECUTABLE)
 
 if(NOT PYTHON_XCBGEN)
-  message(FATAL_ERROR "Missing required python module: xcbgen")
+  message(FATAL_ERROR "Missing required python3 module: xcbgen")
 endif()
 
 #


### PR DESCRIPTION
Including a python2 xcbgen when running python3 leads to errors like
this:

```
File "/usr/lib/python2.7/site-packages/xcbgen/xtypes.py", line 504
  print "Explicit start-align for %s: %s\n" % (self, self.required_start_align)
```

as seen in polybar/polybar#2004 and polybar/polybar#2005
