### PR TITLE
Revert "build: Don't search for xcbgen with python2"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,9 @@ set(XPP_LIBRARIES
 #
 # Loop through a hardcoded list of python executables to locate the python module "xcbgen"
 #
-foreach(CURRENT_EXECUTABLE python python3 python2 python2.7)
+# TODO drop python2 once ubuntu and debian ship python3-xcbgen in their 
+# maintained distros
+foreach(CURRENT_EXECUTABLE python3 python python2 python2.7)
   message(STATUS "Searching for xcbgen with " ${CURRENT_EXECUTABLE})
 
   execute_process(COMMAND "${CURRENT_EXECUTABLE}" "-c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(XPP_LIBRARIES
 #
 # Loop through a hardcoded list of python executables to locate the python module "xcbgen"
 #
-foreach(CURRENT_EXECUTABLE python3 python)
+foreach(CURRENT_EXECUTABLE python python3 python2 python2.7)
   message(STATUS "Searching for xcbgen with " ${CURRENT_EXECUTABLE})
 
   execute_process(COMMAND "${CURRENT_EXECUTABLE}" "-c"
@@ -70,7 +70,7 @@ foreach(CURRENT_EXECUTABLE python3 python)
 endforeach(CURRENT_EXECUTABLE)
 
 if(NOT PYTHON_XCBGEN)
-  message(FATAL_ERROR "Missing required python3 module: xcbgen")
+  message(FATAL_ERROR "Missing required python module: xcbgen")
 endif()
 
 #


### PR DESCRIPTION
Reverts polybar/xpp#21

Both debian and ubuntu don't have their xcbgen scripts in the python3 search path (`python3-xcbgen` is not even in any released distro on ubuntu and only in testing on debian). However, the xcbgen scripts provided under python2 search paths do work with python3 so we can use them.

Ref: polybar/polybar#2031