### PR TITLE
fix: Suppress name mismatch warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(XPP_LIBRARIES
 #
 # Loop through a hardcoded list of python executables to locate the python module "xcbgen"
 #
-# TODO drop python2 once ubuntu and debian ship python3-xcbgen in their 
+# TODO drop python2 once ubuntu and debian ship python3-xcbgen in their
 # maintained distros
 foreach(CURRENT_EXECUTABLE python3 python python2 python2.7)
   message(STATUS "Searching for xcbgen with " ${CURRENT_EXECUTABLE})

--- a/cmake/FindXCB.cmake
+++ b/cmake/FindXCB.cmake
@@ -133,7 +133,7 @@ if(DEFINED unknownComponents)
    return()
 endif()
 
-macro(_XCB_HANDLE_COMPONENT _comp)
+macro(_xcb_handle_component _comp)
     set(_header )
     set(_lib )
     if("${_comp}" STREQUAL "XCB")
@@ -216,7 +216,13 @@ macro(_XCB_HANDLE_COMPONENT _comp)
         list(APPEND requiredComponents XCB_${_comp}_FOUND)
     endif()
 
-    find_package_handle_standard_args(XCB_${_comp} DEFAULT_MSG XCB_${_comp}_LIBRARY XCB_${_comp}_INCLUDE_DIR)
+    find_package_handle_standard_args(XCB_${_comp}
+      REQUIRED_VARS XCB_${_comp}_LIBRARY XCB_${_comp}_INCLUDE_DIR
+      # Bypass developer warning that the first argument to find_package_handle_standard_args (XCB_...) does not match
+      # the name of the calling package (XCB)
+      # https://cmake.org/cmake/help/v3.17/module/FindPackageHandleStandardArgs.html
+      NAME_MISMATCHED
+      )
 
     mark_as_advanced(XCB_${_comp}_LIBRARY XCB_${_comp}_INCLUDE_DIR)
 
@@ -242,7 +248,7 @@ IF (NOT WIN32)
         list(REMOVE_DUPLICATES XCB_INCLUDE_DIRS)
     endif()
 
-    find_package_handle_standard_args(XCB DEFAULT_MSG XCB_LIBRARIES XCB_INCLUDE_DIRS ${requiredComponents})
+    find_package_handle_standard_args(XCB REQUIRED_VARS XCB_LIBRARIES XCB_INCLUDE_DIRS ${requiredComponents})
 
     # compatibility for old variable naming
     set(XCB_INCLUDE_DIR ${XCB_INCLUDE_DIRS})


### PR DESCRIPTION
With cmake 3.17 the following warning would be printed (among other
similar warnings):

  CMake Warning (dev) at /usr/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
    The package name passed to `find_package_handle_standard_args`
    (XCB_COMPOSITE) does not match the name of the calling package (XCB).  This
    can lead to problems in calling code that expects `find_package` result
    variables (e.g., `_FOUND`) to follow a certain pattern.
  Call Stack (most recent call first):
    lib/xpp/cmake/FindXCB.cmake:220 (find_package_handle_standard_args)
    lib/xpp/cmake/FindXCB.cmake:239 (_xcb_handle_component)
    lib/xpp/CMakeLists.txt:135 (find_package)
  This warning is for project developers.  Use -Wno-dev to suppress it.

We properly set XCB_FOUND and all other XCB_* variables, so this should
never be a problem.

Ref: https://cmake.org/cmake/help/v3.17/module/FindPackageHandleStandardArgs.html