### PR TITLE
generators: xml.etree.cElementTree has been dropped in Python 3.9.

### DIFF
--- a/generators/cpp_client.py
+++ b/generators/cpp_client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # vim: set ts=4 sws=4 sw=4:
 
-from xml.etree.cElementTree import *
+from xml.etree.ElementTree import *
 from os.path import basename
 from functools import reduce
 import getopt


### PR DESCRIPTION
It can be replaced with xml.etree.ElementTree safely.

***

Please update the submodule for polybar after merging.

See [the fix in xcbproto](https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/commit/7d58eed95f796fc764741d7549ee2214bbbcc64c) for reference.