### PR TITLE
Search for xcbgen with PYTHON_EXECUTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(XPP_LIBRARIES
 #
 # TODO drop python2 once ubuntu and debian ship python3-xcbgen in their
 # maintained distros
-foreach(CURRENT_EXECUTABLE python3 python python2 python2.7)
+foreach(CURRENT_EXECUTABLE ${PYTHON_EXECUTABLE} python3 python python2 python2.7)
   message(STATUS "Searching for xcbgen with " ${CURRENT_EXECUTABLE})
 
   execute_process(COMMAND "${CURRENT_EXECUTABLE}" "-c"


### PR DESCRIPTION
This way users can specify `-D:PYTHON_EXECUTABLE` to force a certain
python executable and that executable will then also be used to search
for xcbgen.

This should also provide a more universal solution to the configuration
issues with pyenv or conda since the user can just specify
`-D:PYTHON_EXECUTABLE=/usr/bin/python3`.